### PR TITLE
포스트 페이지 하단의 '다른 포스트PostSequenceItem' 링크 구조 변경

### DIFF
--- a/velog-frontend/src/components/post/PostSequences/PostSequences.js
+++ b/velog-frontend/src/components/post/PostSequences/PostSequences.js
@@ -1,9 +1,8 @@
 // @flow
 import React from 'react';
 import type { PostSequence } from 'store/modules/posts';
-import { convertToPlainText, fromNow } from 'lib/common';
+import { fromNow } from 'lib/common';
 import { Link } from 'react-router-dom';
-import FakeLink from 'components/common/FakeLink';
 
 import cx from 'classnames';
 
@@ -25,13 +24,11 @@ const PostSequenceItem = ({ sequence, username, active }: PostSequenceItemProps)
   const { title, body, meta, url_slug, released_at } = sequence;
   const to = `/@${username}/${url_slug}`;
   return (
-    <FakeLink className={cx('PostSequenceItem', { active })} to={to}>
+    <Link className={cx('PostSequenceItem', { active })} to={to} role='link'>
       <div className="date">{fromNow(released_at)}</div>
-      <div className="title">
-        <Link to={to}>{title}</Link>
-      </div>
+      <div className="title">{title}</div>
       <p>{(meta && meta.short_description) || body}</p>
-    </FakeLink>
+    </Link>
   );
 };
 

--- a/velog-frontend/src/components/post/PostSequences/PostSequences.scss
+++ b/velog-frontend/src/components/post/PostSequences/PostSequences.scss
@@ -38,11 +38,9 @@
     .title {
       font-weight: 500;
       font-size: 1.125rem;
-      a {
-        &:hover {
-          text-decoration: underline;
-          color: $oc-violet-5;
-        }
+      &:hover {
+        text-decoration: underline;
+        color: $oc-violet-5;
       }
     }
     p {


### PR DESCRIPTION
휠을 클릭을 해서 새로운 탭으로 띄우고 읽습니다. 이것은 사족이고 개인적인 습관일 뿐이지만, 이 PR의 동기이기에 언급했습니다.

a 태그만으로 가능한 기능을 FakeLink를 통해서 모사할 필요는 없다고 생각해서 직접 PR을 합니다.

의도한대로 작동하는지는 테스트를 해보지 못 했습니다.

P.S. PostSequencesContainer는 Function Component로 재작성을 해도 괜찮을 것이라고 생각하는데, 혹시 Convention인가요?
